### PR TITLE
Ansible playbook to enable FIPS and install Satellite 6.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 
 # Galaxy Roles
 galaxy_roles/
+
+# Variable samples
+vars/satellite_common.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ docs/_build/
 
 # Galaxy Roles
 galaxy_roles/
+mazer_roles/
 
 # Variable samples
 vars/satellite_common.local.yml

--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ Befor running any Satellite6 playbooks,
    # ansible-galaxy install -r requirements.yml
    ```
 
-2. Check and configure required variables
+2. Check and configure required variables in `satellite_common.local.yml`
+   by first making a copy of it.
    (i.e RHSM Credentials, Satellite setup links and so on).
+
+   ```
+   cp satellite_common.yml satellite_common.local.yml
+   ```
 
 3. Make a copy of inventory from inventory.sample file. 
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ We also recommend to install yamllint, ansible-lint and ansible-review.
 
 Befor running any Satellite6 playbooks,
 
-1. Check and Install the roles from ansible galaxy, if any
+1. Check and Install dependent roles from ansible galaxy and [mazer](https://galaxy.ansible.com/docs/mazer/install.html), if any
 
    ```
    # ansible-galaxy install -r requirements.yml
+   # mazer install --namespace forklift git+https://github.com/theforeman/forklift
    ```
 
 2. Check and configure required variables in `satellite_common.local.yml`

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,8 +1,9 @@
 [defaults]
 library = foreman-ansible-modules/modules
 module_utils = foreman-ansible-modules/module_utils
-roles_path = $PWD/galaxy_roles:$PWD/roles
+roles_path = $PWD/galaxy_roles:$PWD/roles:$PWD/galaxy_roles/pulp-ci/pulp-ci/ci/ansible/roles:$PWD/mazer_roles/forklift/forklift/roles
 inventory = inventory_files/inventory
 retry_files_enabled = False
 stdout_callback = yaml
 display_skipped_hosts = False
+timeout = 10

--- a/playbooks/install/satellite_63.yml
+++ b/playbooks/install/satellite_63.yml
@@ -1,4 +1,11 @@
 ---
 - hosts: sat63
+  vars_files:
+    - ../../vars/satellite_common.local.yml
+    - ../../vars/satellite_63.yml
   roles:
     - partition-disk
+    - redhat_subscriptions
+    - satellite6_repositories
+    - update_os_packages
+    - install_satellite6

--- a/playbooks/install/satellite_64.yml
+++ b/playbooks/install/satellite_64.yml
@@ -1,4 +1,11 @@
 ---
 - hosts: sat64
+  vars_files:
+    - ../../vars/satellite_common.local.yml
+    - ../../vars/satellite_64.yml
   roles:
     - partition-disk
+    - redhat_subscriptions
+    - satellite6_repositories
+    - update_os_packages
+    - install_satellite6

--- a/playbooks/install/satellite_64_fips.yml
+++ b/playbooks/install/satellite_64_fips.yml
@@ -1,0 +1,21 @@
+---
+- hosts: sat64
+  vars_files:
+    - ../../vars/satellite_common.local.yml
+    - ../../vars/satellite_64.yml
+    - ../../vars/satellite_fips.yml
+  roles:
+    - pulp-fips
+    - satellite6_repositories
+    - puppet_repositories
+    - update_os_packages
+    - epel_repositories
+    - foreman_repositories
+    - katello_repositories
+    - install_katello
+    - katello_client
+    - partition-disk
+    - redhat_subscriptions
+    - install_satellite6
+    - fips_workaround
+    - foreman_installer

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,6 @@
 ---
 # from galaxy
 # - src: username.rolename
+
+# from git
+- src: https://github.com/pulp/pulp-ci

--- a/roles/enable-fips/README.md
+++ b/roles/enable-fips/README.md
@@ -1,0 +1,44 @@
+Ansible Role for Enabling FIPS
+==============================
+
+This Ansible role enables FIPS for a remote host.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No variables required for this role.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of enable-fips role:
+
+- hosts: localhost
+  remote_user: root
+  roles:
+    - enable-fips
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/enable-fips/defaults/main.yml
+++ b/roles/enable-fips/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for enable-fips

--- a/roles/enable-fips/handlers/main.yml
+++ b/roles/enable-fips/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for enable-fips

--- a/roles/enable-fips/meta/main.yml
+++ b/roles/enable-fips/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/enable-fips/tasks/edit_kernel.yml
+++ b/roles/enable-fips/tasks/edit_kernel.yml
@@ -1,0 +1,7 @@
+---
+- name: "Get boot_uuid"
+  command: 'findmnt -no uuid /boot'
+  register: uuid
+
+- name: "Edit kernel fips and boot arguments"
+  command: 'grubby --update-kernel=DEFAULT --args="fips=1 boot=UUID={{ uuid.stdout }}"'

--- a/roles/enable-fips/tasks/install_dracut.yml
+++ b/roles/enable-fips/tasks/install_dracut.yml
@@ -1,0 +1,8 @@
+---
+- name: "Install dracut-fips"
+  package:
+    name: dracut-fips
+    state: present
+
+- name: "Run dracut"
+  command: dracut --force

--- a/roles/enable-fips/tasks/main.yml
+++ b/roles/enable-fips/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: "Check if FIPS is enabled"
+  slurp:
+    src: '/proc/sys/crypto/fips_enabled'
+  register: fips
+
+- block:
+  - include_tasks: install_dracut.yml
+  - include_tasks: edit_kernel.yml
+  - include_tasks: reboot.yml
+  when: fips.content|b64decode|trim == "0"

--- a/roles/enable-fips/tasks/reboot.yml
+++ b/roles/enable-fips/tasks/reboot.yml
@@ -1,0 +1,10 @@
+---
+- name: "Restart host"
+  shell: 'sleep 2 && shutdown -r now'
+  async: 1
+  poll: 0
+  ignore_errors: true
+
+- name: "Wait for reboot"
+  become: false
+  local_action: wait_for host={{ inventory_hostname }} port=22 state=started delay=10

--- a/roles/enable-fips/tests/inventory
+++ b/roles/enable-fips/tests/inventory
@@ -1,0 +1,2 @@
+[sat63]
+sat63-rhel7 ansible_ssh_host=sat63-rhel7.example.com ansible_user=root

--- a/roles/enable-fips/tests/test.yml
+++ b/roles/enable-fips/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sat63
+  roles:
+    - enable-fips

--- a/roles/enable-fips/vars/main.yml
+++ b/roles/enable-fips/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for enable-fips

--- a/roles/fips_workaround/README.md
+++ b/roles/fips_workaround/README.md
@@ -1,0 +1,44 @@
+Ansible Role for Enabling FIPS
+==============================
+
+This Ansible role downloads and runs a script apply a set of patches for installing Satellite on a FIPS-enabled machine.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+fips_script: link to workaround script for installing FIPS
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of fips_workaround role:
+
+- hosts: localhost
+  remote_user: root
+  roles:
+    - fips_workaround
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/fips_workaround/defaults/main.yml
+++ b/roles/fips_workaround/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for fips_workaround
+fips_script: https://gist.githubusercontent.com/iNecas/8cd95a07ce1700068307020e2beb0441/raw/efaadad7c7b971f74d461b04e96a1d0ae45a403e/fips_workaround.sh

--- a/roles/fips_workaround/handlers/main.yml
+++ b/roles/fips_workaround/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for fips_workaround

--- a/roles/fips_workaround/meta/main.yml
+++ b/roles/fips_workaround/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/fips_workaround/tasks/main.yml
+++ b/roles/fips_workaround/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for fips_workaround
+- name: "Download fips_workaround script"
+  get_url:
+    url: "{{ fips_script }}"
+    dest: ~/
+
+- name: "Run fips_workaround script"
+  command: bash ~/fips_workaround.sh
+  tags:
+  - skip_ansible_lint

--- a/roles/fips_workaround/tests/inventory
+++ b/roles/fips_workaround/tests/inventory
@@ -1,0 +1,2 @@
+[sat63]
+sat63-rhel7 ansible_ssh_host=sat63-rhel7.example.com ansible_user=root

--- a/roles/fips_workaround/tests/test.yml
+++ b/roles/fips_workaround/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sat63
+  roles:
+    - fips_workaround

--- a/roles/fips_workaround/vars/main.yml
+++ b/roles/fips_workaround/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for fips_workaround

--- a/roles/install_katello/README.md
+++ b/roles/install_katello/README.md
@@ -1,0 +1,43 @@
+Ansible Role for Installing Katello packages. 
+================================================
+
+This Ansible role installs Katello.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No Variables required for this role.
+
+Dependencies
+------------
+
+forklift/katello_repositories
+
+Example Playbook
+----------------
+
+Here is a simple example of install_katello role:
+
+- hosts: localhost
+  roles:
+    - install_katello
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/install_katello/defaults/main.yml
+++ b/roles/install_katello/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for install_katello

--- a/roles/install_katello/handlers/main.yml
+++ b/roles/install_katello/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for install_katello

--- a/roles/install_katello/meta/main.yml
+++ b/roles/install_katello/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/install_katello/tasks/main.yml
+++ b/roles/install_katello/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# Tasks file for install_katello
+- name: Install the latest version of Katello
+  yum:
+    name: katello
+    state: present

--- a/roles/install_katello/tests/inventory
+++ b/roles/install_katello/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/install_katello/tests/test.yml
+++ b/roles/install_katello/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - install_katello

--- a/roles/install_katello/vars/main.yml
+++ b/roles/install_katello/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for install_katello

--- a/roles/install_satellite6/README.md
+++ b/roles/install_satellite6/README.md
@@ -1,0 +1,45 @@
+Ansible Role for Installing Satellite6 packages. 
+================================================
+
+This Ansible role installs Satellite6 packages.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No Variables required for this role.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of install_satellite6 role:
+
+- hosts: localhost
+  roles:
+    - redhat_subscriptions
+    - satellite6_repositories
+    - install_satellite6
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/install_satellite6/defaults/main.yml
+++ b/roles/install_satellite6/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for install_satellite6

--- a/roles/install_satellite6/handlers/main.yml
+++ b/roles/install_satellite6/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for install_satellite6

--- a/roles/install_satellite6/meta/main.yml
+++ b/roles/install_satellite6/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/install_satellite6/tasks/main.yml
+++ b/roles/install_satellite6/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# Tasks file for install_satellite6
+- name: Install the latest version of Satellite6
+  yum:
+    name: satellite
+    state: present

--- a/roles/install_satellite6/tests/inventory
+++ b/roles/install_satellite6/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/install_satellite6/tests/test.yml
+++ b/roles/install_satellite6/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - install_satellite6

--- a/roles/install_satellite6/vars/main.yml
+++ b/roles/install_satellite6/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for install_satellite6

--- a/roles/redhat_subscriptions/README.md
+++ b/roles/redhat_subscriptions/README.md
@@ -1,0 +1,45 @@
+Ansible Role for Registering and Subscribing content
+====================================================
+
+This Ansible role registers and subscribes Satellite6 node with RHN.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+Requires redhat_subscriptions_rhsm_username and redhat_subscriptions_rhsm_password to be set if using internal_repo or CDN.
+
+Requires redhat_subscriptions_activation_key and redhat_subscriptions_organization to be set if using internal_ak.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of partitioning-disk role:
+
+- hosts: localhost
+  roles:
+    - redhat_subscriptions
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/redhat_subscriptions/defaults/main.yml
+++ b/roles/redhat_subscriptions/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for redhat_subscriptions
+redhat_subscriptions_rhsm_username: user@redhat.com
+redhat_subscriptions_rhsm_password: fake_password

--- a/roles/redhat_subscriptions/handlers/main.yml
+++ b/roles/redhat_subscriptions/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for redhat_subscriptions

--- a/roles/redhat_subscriptions/meta/main.yml
+++ b/roles/redhat_subscriptions/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/redhat_subscriptions/tasks/activation_key.yml
+++ b/roles/redhat_subscriptions/tasks/activation_key.yml
@@ -1,0 +1,14 @@
+---
+- name: Install katello-ca-consumer-latest
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "7"
+  yum:
+    name: "{{ repository_url }}/pub/katello-ca-consumer-latest.noarch.rpm"
+    state: present
+
+- name: Register with activationkey and consume subscriptions from Dogfood Server.
+  redhat_subscription:
+    state: present
+    activationkey: "{{ redhat_subscriptions_activation_key }}"
+    org_id: "{{ redhat_subscriptions_organization }}"

--- a/roles/redhat_subscriptions/tasks/install_rhsm.yml
+++ b/roles/redhat_subscriptions/tasks/install_rhsm.yml
@@ -1,0 +1,5 @@
+---
+- name: "Install Red Hat Subscription Manager"
+  yum:
+    name: subscription-manager
+    state: present

--- a/roles/redhat_subscriptions/tasks/main.yml
+++ b/roles/redhat_subscriptions/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+# tasks file for redhat_subscriptions
+- include_tasks: username_and_password.yml
+  when: (satellite_distribution == "internal_repo") or
+        (satellite_distribution == "cdn")
+- include_tasks: activation_key.yml
+  when: satellite_distribution == "internal_ak"

--- a/roles/redhat_subscriptions/tasks/main.yml
+++ b/roles/redhat_subscriptions/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # tasks file for redhat_subscriptions
+- include_tasks: install_rhsm.yml
+  when: ansible_distribution == "CentOS"
 - include_tasks: username_and_password.yml
   when: (satellite_distribution == "internal_repo") or
         (satellite_distribution == "cdn")

--- a/roles/redhat_subscriptions/tasks/username_and_password.yml
+++ b/roles/redhat_subscriptions/tasks/username_and_password.yml
@@ -1,0 +1,17 @@
+---
+# tasks file for redhat_subscriptions
+- name: "Register and Subscribe RHEL Instance to RHN."
+  when:
+    - (satellite_distribution == "internal_repo") or
+      (satellite_distribution == "cdn")
+    - ansible_distribution == "RedHat"
+    - redhat_subscriptions_rhsm_username is defined
+    - redhat_subscriptions_rhsm_password is defined
+  redhat_subscription:
+    state: present
+    username: "{{ redhat_subscriptions_rhsm_username }}"
+    password: "{{ redhat_subscriptions_rhsm_password }}"
+    pool_ids:
+      - "{{ redhat_subscriptions_rhsm_pool_id1 }}"
+      - "{{ redhat_subscriptions_rhsm_pool_id2 }}"
+    force_register: true

--- a/roles/redhat_subscriptions/tasks/username_and_password.yml
+++ b/roles/redhat_subscriptions/tasks/username_and_password.yml
@@ -4,7 +4,7 @@
   when:
     - (satellite_distribution == "internal_repo") or
       (satellite_distribution == "cdn")
-    - ansible_distribution == "RedHat"
+    - (ansible_distribution == "RedHat") or (ansible_distribution == "CentOS")
     - redhat_subscriptions_rhsm_username is defined
     - redhat_subscriptions_rhsm_password is defined
   redhat_subscription:

--- a/roles/redhat_subscriptions/tests/inventory
+++ b/roles/redhat_subscriptions/tests/inventory
@@ -1,0 +1,2 @@
+[sat63]
+sat63-rhel7 ansible_ssh_host=sat63-rhel7.example.com ansible_user=root

--- a/roles/redhat_subscriptions/tests/test.yml
+++ b/roles/redhat_subscriptions/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sat63
+  roles:
+    - redhat_subscriptions

--- a/roles/redhat_subscriptions/vars/main.yml
+++ b/roles/redhat_subscriptions/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for redhat_subscriptions

--- a/roles/satellite6_repositories/README.md
+++ b/roles/satellite6_repositories/README.md
@@ -1,0 +1,49 @@
+Ansible Role for Registering and Subscribing content
+====================================================
+
+This Ansible role manages disabling and enabling of repositories for Satellite6.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+Requires satellite_distribution to be set.
+The valid values for satellite_distribution are internal_repo, internal_ak and cdn.
+
+Requires satellite_version value correctly set.
+
+Requires satellite6_repositories_satellite_reponame and satellite6_repositories_satellite_repourl to be set, if using internal_repo.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of satellite6_repositories role:
+
+- hosts: localhost
+  roles:
+    - redhat_subscriptions
+    - satellite6_repositories
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/satellite6_repositories/defaults/main.yml
+++ b/roles/satellite6_repositories/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for satellite6_repositories

--- a/roles/satellite6_repositories/handlers/main.yml
+++ b/roles/satellite6_repositories/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for satellite6_repositories

--- a/roles/satellite6_repositories/meta/main.yml
+++ b/roles/satellite6_repositories/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/satellite6_repositories/tasks/disable_repositories.yml
+++ b/roles/satellite6_repositories/tasks/disable_repositories.yml
@@ -1,0 +1,19 @@
+---
+# tasks file for satellite6_repositories
+- name: "Install yum-utils"
+  package:
+    name: yum-utils
+    state: present
+
+- name: Disable all RHSM repositories
+  when: (satellite_distribution == "internal_repo") or
+        (satellite_distribution == "cdn")
+  rhsm_repository:
+    name: '*'
+    state: disabled
+
+- name: "Disable all Beaker Repos"
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "7"
+  command: yum-config-manager --disable "beaker*"

--- a/roles/satellite6_repositories/tasks/enable_repositories.yml
+++ b/roles/satellite6_repositories/tasks/enable_repositories.yml
@@ -1,0 +1,44 @@
+---
+# tasks file for satellite6_repositories
+- name: "Enable all the required repositories for Satellite6 Installation via CDN."
+  when: (satellite_distribution == "internal_repo") or
+        (satellite_distribution == "cdn")
+  rhsm_repository:
+    name: "{{ item }}"
+    state: enabled
+  with_items:
+     - "rhel-{{ ansible_distribution_major_version }}-server-rpms"
+     - "rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
+     - "rhel-{{ ansible_distribution_major_version }}-server-extras-rpms"
+     - "rhel-{{ ansible_distribution_major_version }}-server-ansible-2-rpms"
+     - "rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms"
+
+- block:
+  - name: "Enable Satellite-Maintenance repository via CDN."
+    rhsm_repository:
+      name: "rhel-{{ ansible_distribution_major_version }}-server-satellite-maintenance-6-rpms"
+      state: enabled
+
+  - name: "Enable Satellite6 repository via CDN."
+    rhsm_repository:
+      name: "rhel-{{ ansible_distribution_major_version }}-server-satellite-{{ satellite_version }}-rpms"
+      state: enabled
+  when:
+    - satellite_distribution == "cdn"
+
+- block:
+  - name: "Add Internal Satellite-Maintenance repository."
+    yum_repository:
+      name: "{{ satellite6_repositories_satellite_maintain_reponame }}"
+      description: "{{ satellite6_repositories_satellite_maintain_reponame }} repository"
+      baseurl: "{{ satellite6_repositories_satellite_maintain_repourl }}"
+      gpgcheck: no
+
+  - name: "Add Internal Satellite 6 repository."
+    yum_repository:
+      name: "{{ satellite6_repositories_satellite_reponame }}"
+      description: "{{ satellite6_repositories_satellite_reponame }} repository"
+      baseurl: "{{ satellite6_repositories_satellite_repourl }}"
+      gpgcheck: no
+  when:
+    - satellite_distribution == "internal_repo"

--- a/roles/satellite6_repositories/tasks/main.yml
+++ b/roles/satellite6_repositories/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+# tasks file for redhat_subscriptions
+- include_tasks: disable_repositories.yml
+- include_tasks: enable_repositories.yml
+  when: (satellite_distribution == "internal_repo") or
+        (satellite_distribution == "cdn")

--- a/roles/satellite6_repositories/tests/inventory
+++ b/roles/satellite6_repositories/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/satellite6_repositories/tests/test.yml
+++ b/roles/satellite6_repositories/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - satellite6_repositories

--- a/roles/satellite6_repositories/vars/main.yml
+++ b/roles/satellite6_repositories/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for satellite6_repositories

--- a/roles/update_os_packages/README.md
+++ b/roles/update_os_packages/README.md
@@ -1,0 +1,45 @@
+Ansible Role for updating OS packages. 
+================================================
+
+This Ansible role for updating OS packages.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No Variables required for this role.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of install_satellite6 role:
+
+- hosts: localhost
+  roles:
+    - redhat_subscriptions
+    - satellite6_repositories
+    - update_os_packages
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/update_os_packages/defaults/main.yml
+++ b/roles/update_os_packages/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for update_os_packages

--- a/roles/update_os_packages/handlers/main.yml
+++ b/roles/update_os_packages/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for update_os_packages

--- a/roles/update_os_packages/meta/main.yml
+++ b/roles/update_os_packages/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/update_os_packages/tasks/main.yml
+++ b/roles/update_os_packages/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# tasks file for update_os_packages
+- name: yum clean all
+  command: 'yum clean all'
+
+- name: Update all installed packages before installing Satellite6
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "7"
+  yum:
+    name: '*'
+    update_cache: yes
+    state: latest
+  tags:
+    - skip_ansible_lint
+
+# TODO, investigate reboot here and add.
+# https://github.com/SatelliteQE/ansible-satellite6/issues/8

--- a/roles/update_os_packages/tests/inventory
+++ b/roles/update_os_packages/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/update_os_packages/tests/test.yml
+++ b/roles/update_os_packages/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - update_os_packages

--- a/roles/update_os_packages/vars/main.yml
+++ b/roles/update_os_packages/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for update_os_packages

--- a/vars/satellite_63.yml
+++ b/vars/satellite_63.yml
@@ -1,0 +1,10 @@
+---
+# Satellite 63
+satellite_version: "6.3"
+
+redhat_subscriptions_activation_key: "satellite-6.3.0-qa-rhel7"
+redhat_subscriptions_organization: "Sat6-CI"
+
+#  Satellite_63_Composes
+satellite6_repositories_satellite_reponame: "Satellite_63_RHEL7"
+satellite6_repositories_satellite_repourl: "{{ repository_url }}/pulp/repos/Sat6-CI/QA/Satellite_6_3_with_RHEL7_Server/custom/Satellite_6_3_Composes/Satellite_6_3_RHEL7"

--- a/vars/satellite_64.yml
+++ b/vars/satellite_64.yml
@@ -1,0 +1,10 @@
+---
+# Satellite 64
+satellite_version: "6.4"
+
+redhat_subscriptions_activation_key: "satellite-6.4.0-qa-rhel7"
+redhat_subscriptions_organization: "Sat6-CI"
+
+#  Satellite_64_Composes
+satellite6_repositories_satellite_reponame: "Satellite_64_RHEL7"
+satellite6_repositories_satellite_repourl: "{{ repository_url }}/pulp/repos/Sat6-CI/QA/Satellite_6_4_with_RHEL7_Server/custom/Satellite_6_4_Composes/Satellite_6_4_RHEL7"

--- a/vars/satellite_common.yml
+++ b/vars/satellite_common.yml
@@ -1,0 +1,31 @@
+---
+redhat_subscriptions_rhsm_username: "user@redhat.com"
+redhat_subscriptions_rhsm_password: "updatethisvalue"
+
+# Pass the pool-id which would have all the below repos available.
+#
+# Below for example:
+# Satellite Employee Subscriptions brings in all below repos.
+
+# "rhel-7-server-rpms"
+# "rhel-7-server-satellite-maintenance-6-rpms"
+# "rhel-server-rhscl-7-rpms"
+# "rhel-7-server-satellite-6.x-rpms"
+
+# Employee SKU brings in the below repos.
+# "rhel-7-server-ansible-2-rpms"
+
+# Satellite Employee subscriptions for all other Product/Repos.
+redhat_subscriptions_rhsm_pool_id1: 8a85f981519abf020151a22d3c387f2a
+# Employee SKU for 'Red Hat Ansible Engine Product'.
+redhat_subscriptions_rhsm_pool_id2: 8a85f98960dbf6510160df23e3367451
+
+# Repository URL
+repository_url: "http://repository.example.com"
+
+# Valid values are, "internal_repo", "cdn", "internal_ak".
+satellite_distribution: "cdn"
+
+# Maintain URL
+satellite6_repositories_satellite_maintain_reponame: "Satellite6_Maintain_RHEL7"
+satellite6_repositories_satellite_maintain_repourl: "{{ repository_url }}/pulp/repos/Sat6-CI/QA/Satellite_Maintenance_RHEL7/custom/Satellite_Maintenance_Composes/Satellite_Maintenance_RHEL7/"

--- a/vars/satellite_fips.yml
+++ b/vars/satellite_fips.yml
@@ -1,0 +1,25 @@
+---
+# Red Hat Subscription Manager variables
+rhn_username: '{{ vars["redhat_subscriptions_rhsm_username"] }}'
+rhn_password: '{{ vars["redhat_subscriptions_rhsm_password"] }}'
+rhn_pool: '{{ vars["redhat_subscriptions_rhsm_pool_id1"] }}'
+
+# Pulp variables
+pulp_version: '2.16'
+pulp_build: 'nightly'
+
+# Foreman installer variables
+foreman_installer_scenario: satellite
+foreman_installer_command: satellite-installer
+foreman_installer_options_internal_use_only:
+- "--disable-system-checks"
+- "--foreman-admin-password {{ foreman_installer_admin_password }}"
+
+# Katello client server
+katello_client_server: "sat-r220-02.lab.eng.rdu2.redhat.com/"
+katello_client_organization: Sat6-CI
+katello_client_activationkey: "satellite-6.4.0-qa-rhel7"
+
+# Valid values are, "internal_repo", "cdn", "internal_ak"
+# satellite_64_fips.yml fails for "internal_repo" and "cdn" distribution types
+satellite_distribution: "internal_ak"


### PR DESCRIPTION
Added new roles to install katello and run the katello fips_workaround script, edited redhat_subscriptions to support CentOS, and updated documentation, configs, etc. to reflect changes.