### PR TITLE
satellite_firewall role

### DIFF
--- a/roles/satellite_firewall/README.md
+++ b/roles/satellite_firewall/README.md
@@ -45,7 +45,7 @@ This role is not dependent upon any galaxy roles.
 Example Playbook
 ----------------
 
-Here is a simple example of partitioning-disk role:
+Here is a simple example of satellite_firewall role:
 
 - hosts: localhost
   roles:

--- a/roles/satellite_firewall/README.md
+++ b/roles/satellite_firewall/README.md
@@ -1,0 +1,66 @@
+Role Name
+=========
+
+This Ansible role configures firewall on a server running Satellite 6, and opens ports required by Satellite to function. 
+List of ports is taken from Satellite documentation 
+
+https://access.redhat.com/documentation/en-us/red_hat_satellite/6.3/html/installation_guide/preparing_your_environment_for_installation#ports_prerequisites
+
+and from automation-tools available at 
+
+https://github.com/SatelliteQE/automation-tools/blob/master/automation_tools/__init__.py#L623-L664   
+
+Requirements
+------------
+
+No requirements are required for this role.
+
+Role Variables
+--------------
+
+Requires lists of ports to open in the following wariables:
+- *common_ports*
+- *satellite_ports*
+- *capsule_ports*
+
+Format of the item contained in the port list is as follows:
+
+*\- {proto: '\<protocol\>', port: \<port number\>}*
+
+For example to open the port 22 for TCP:
+
+\- {proto: 'tcp', port: 22}
+
+See the current list of ports to open in the global *vars/satellite_common.yml* file. 
+
+As a Satellite 6 server contains an integrated capsule, we should open both satellite and capsule ports.
+A role configuring firewall for a server running only stand-alone capsule should use only *common_ports* and
+*capsule_ports* variables.   
+  
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of partitioning-disk role:
+
+- hosts: localhost
+  roles:
+    - satellite_firewall
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/satellite_firewall/defaults/main.yml
+++ b/roles/satellite_firewall/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for satellite_firewall

--- a/roles/satellite_firewall/handlers/main.yml
+++ b/roles/satellite_firewall/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for satellite_firewall

--- a/roles/satellite_firewall/meta/main.yml
+++ b/roles/satellite_firewall/meta/main.yml
@@ -1,0 +1,20 @@
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+        - 6
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/satellite_firewall/tasks/main.yml
+++ b/roles/satellite_firewall/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Make sure the firewalld package is present
+  yum:
+    name: firewalld
+    state: present
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version|int >= 7
+
+- name: Open Satellite ports using firewalld
+  firewalld:
+    port: "{{ item.port }}/{{ item.proto }}"
+    permanent: true
+    state: enabled
+    immediate: true
+  with_flattened:
+    - "{{ common_ports }}"
+    - "{{ satellite_ports }}"
+    - "{{ capsule_ports }}"
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version|int >= 7
+
+- name: Open Satellite ports using iptables
+  iptables:
+    chain: INPUT
+    ctstate: NEW
+    destination_port: "{{ item.port }}"
+    protocol: "{{ item.proto }}"
+    jump: ACCEPT
+  with_flattened:
+    - "{{ common_ports }}"
+    - "{{ satellite_ports }}"
+    - "{{ capsule_ports }}"
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version|int < 7

--- a/roles/satellite_firewall/tests/inventory
+++ b/roles/satellite_firewall/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/satellite_firewall/tests/test.yml
+++ b/roles/satellite_firewall/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - satellite_firewall

--- a/roles/satellite_firewall/vars/main.yml
+++ b/roles/satellite_firewall/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for satellite_firewall

--- a/vars/satellite_common.yml
+++ b/vars/satellite_common.yml
@@ -51,7 +51,7 @@ satellite_ports:
   - {proto: 'tcp', port: 5671}
   - {proto: 'tcp', port: 2375}
   - {proto: 'tcp', port: 5000}
-  - {proto: 'tcp', port: 16500}
+  - {proto: 'tcp', port: 16509}
 
 capsule_ports:
   - {proto: 'tcp', port: 53}

--- a/vars/satellite_common.yml
+++ b/vars/satellite_common.yml
@@ -29,3 +29,31 @@ satellite_distribution: "cdn"
 # Maintain URL
 satellite6_repositories_satellite_maintain_reponame: "Satellite6_Maintain_RHEL7"
 satellite6_repositories_satellite_maintain_repourl: "{{ repository_url }}/pulp/repos/Sat6-CI/QA/Satellite_Maintenance_RHEL7/custom/Satellite_Maintenance_Composes/Satellite_Maintenance_RHEL7/"
+
+# Ports needed both by a Sat 6 server and by a Capsule server to be open
+# List of ports taken from https://github.com/SatelliteQE/automation-tools/blob/master/automation_tools/__init__.py#L623-L664
+# and from Satellite 6 documentation
+#(https://access.redhat.com/documentation/en-us/red_hat_satellite/6.3/html/installation_guide/preparing_your_environment_for_installation#ports_prerequisites)
+common_ports:
+  - {proto: 'tcp', port: 22}
+  - {proto: 'tcp', port: 80}
+  - {proto: 'tcp', port: 443}
+  - {proto: 'tcp', port: 5647}
+  - {proto: 'tcp', port: 8000}
+  - {proto: 'tcp', port: 8140}
+  - {proto: 'tcp', port: 8443}
+  - {proto: 'tcp', port: 9090}
+  - {proto: 'udp', port: 53}
+  - {proto: 'udp', port: 69}
+
+satellite_ports:
+  - {proto: 'tcp', port: 5646}
+  - {proto: 'tcp', port: 5671}
+  - {proto: 'tcp', port: 2375}
+  - {proto: 'tcp', port: 5000}
+  - {proto: 'tcp', port: 16500}
+
+capsule_ports:
+  - {proto: 'tcp', port: 53}
+  - {proto: 'udp', port: 67}
+  - {proto: 'udp', port: 68}


### PR DESCRIPTION
Initial version of satellite_firewall role. Opens network ports required by Satellite 6 to work correctly, both using firewalld (RHEL7+) or iptables (RHEL6 and lower). 