### PR TITLE
chrony (NTP) role

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,3 @@
 ---
 # from galaxy
-# - src: username.rolename
+- src: oasis-roles.chrony

--- a/roles/chrony/README.md
+++ b/roles/chrony/README.md
@@ -1,0 +1,44 @@
+Ansible Role for Configuring NTP using chrony
+==================================
+
+This Ansible role installs the chrony and ensures desired configuration.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No variables required for this role.
+
+Dependencies
+------------
+
+This role is dependent on Galaxy oasis-roles.chrony role.
+
+Example Playbook
+----------------
+
+Here is a simple example of chrony role:
+
+- hosts: localhost
+  remote_user: root
+  roles:
+    - chrony
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/chrony/meta/main.yml
+++ b/roles/chrony/meta/main.yml
@@ -1,0 +1,21 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 6
+        - 7
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# tasks file for chrony
+- name: Install libselinux-python
+  yum:
+    name: libselinux-python
+    state: present
+
+- name: Configure chrony
+  include_role:
+    name: oasis-roles.chrony

--- a/roles/chrony/tests/inventory
+++ b/roles/chrony/tests/inventory
@@ -1,0 +1,2 @@
+[sat63]
+sat63-rhel7 ansible_ssh_host=sat63-rhel7.example.com ansible_user=root

--- a/roles/chrony/tests/test.yml
+++ b/roles/chrony/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sat63
+  roles:
+    - chrony


### PR DESCRIPTION
Initial version of chrony role, that configures and enables the chronyd service.
I did make use of one of the [OASIS roles](https://galaxy.ansible.com/oasis-roles) to not to duplicate the effort. This role is also configurable. I left our defaults empty thus using defaults of the OASIS chrony role.

Works on RHEL7 and RHEL6.