### PR TITLE
clean_rhsm role

### DIFF
--- a/roles/clean_rhsm/README.md
+++ b/roles/clean_rhsm/README.md
@@ -1,0 +1,44 @@
+Ansible Role for Cleaning up RHSM
+==================================
+
+This Ansible role removes Candlepin certs and sets RHSM config file to its default state.
+
+Requirements
+------------
+
+No Requirements are required for this role.
+
+Role Variables
+--------------
+
+No variables required for this role.
+
+Dependencies
+------------
+
+This role is not dependent upon any galaxy roles.
+
+Example Playbook
+----------------
+
+Here is a simple example of clean_rhsm role:
+
+- hosts: localhost
+  remote_user: root
+  roles:
+    - clean_rhsm
+
+License
+-------
+
+ GNU GENERAL PUBLIC LICENSE
+
+    Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc.
+
+
+Author Information
+------------------
+
+This is developed by Satellite QE team, irc: #robottelo on Freenode

--- a/roles/clean_rhsm/defaults/main.yml
+++ b/roles/clean_rhsm/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+rhsm_conf: /etc/rhsm/rhsm.conf

--- a/roles/clean_rhsm/meta/main.yml
+++ b/roles/clean_rhsm/meta/main.yml
@@ -1,0 +1,21 @@
+---
+# Standards: 0.2
+galaxy_info:
+  author: Satellite QE Team
+  description: Satellite QE Team
+  company: Red Hat
+
+  license: GPLv3
+
+  min_ansible_version: 2.5.0
+
+  platforms:
+    - name: RHEL
+      versions:
+        - 7
+        - 6
+
+  galaxy_tags: []
+
+
+dependencies: []

--- a/roles/clean_rhsm/tasks/main.yml
+++ b/roles/clean_rhsm/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: "Erase existing Candlepin certs, if any."
+  yum:
+    name: katello-ca-consumer-*
+    state: absent
+
+- name: Erase katello-server-ca.pem
+  file:
+    path: /etc/rhsm/ca/katello-server-ca.pem
+    state: absent
+
+- name: "Change 'hostname' to 'subscription.rhsm.redhat.com'"
+  ini_file:
+    path: "{{ rhsm_conf }}"
+    section: server
+    option: hostname
+    value: subscription.rhsm.redhat.com
+
+- name: "Change 'prefix' to '/subscription'"
+  ini_file:
+    path: "{{ rhsm_conf }}"
+    section: server
+    option: prefix
+    value: /subscription
+
+- name: "Change baseurl to 'https://cdn.redhat.com'"
+  ini_file:
+    path: "{{ rhsm_conf }}"
+    section: rhsm
+    option: baseurl
+    value: https://cdn.redhat.com
+
+- name: "Change repo_ca_cert to '%(ca_cert_dir)sredhat-uep.pem'"
+  ini_file:
+    path: "{{ rhsm_conf }}"
+    section: rhsm
+    option: repo_ca_cert
+    value: "%(ca_cert_dir)sredhat-uep.pem"

--- a/roles/clean_rhsm/tests/inventory
+++ b/roles/clean_rhsm/tests/inventory
@@ -1,0 +1,2 @@
+[sat63]
+sat63-rhel7 ansible_ssh_host=sat63-rhel7.example.com ansible_user=root

--- a/roles/clean_rhsm/tests/test.yml
+++ b/roles/clean_rhsm/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sat63
+  roles:
+    - clean_rhsm


### PR DESCRIPTION
While creating this role I copied the steps from the [`clean_rhsm` function](https://github.com/SatelliteQE/automation-tools/blob/master/automation_tools/__init__.py#L2639-L2651) from automation-tools.
The extra step that this role does is that it removes `/etc/rhsm/ca/katello-server-ca.pem` which always remains on the host. For instance, the bootstrap.py is removing this file.