### PR TITLE
Remove some ugliness preventing sane usage of the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ Befor running any Satellite6 playbooks,
    # ansible-galaxy install -r requirements.yml
    ```
 
-2. Check and configure required variables in `satellite_common.local.yml`
-   by first making a copy of it.
+2. Check and configure required variables in `satellite_common.yml`
    (i.e RHSM Credentials, Satellite setup links and so on).
 
    ```
-   cp satellite_common.yml satellite_common.local.yml
+   vim satellite_common.yml
    ```
 
 3. Make a copy of inventory from inventory.sample file. 

--- a/playbooks/install/satellite_63.yml
+++ b/playbooks/install/satellite_63.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: sat63
+- hosts: all
+  become: true
   vars_files:
-    - ../../vars/satellite_common.local.yml
+    - ../../vars/satellite_common.yml
     - ../../vars/satellite_63.yml
   roles:
     - partition-disk

--- a/playbooks/install/satellite_64.yml
+++ b/playbooks/install/satellite_64.yml
@@ -1,7 +1,8 @@
 ---
-- hosts: sat64
+- hosts: all
+  become: true
   vars_files:
-    - ../../vars/satellite_common.local.yml
+    - ../../vars/satellite_common.yml
     - ../../vars/satellite_64.yml
   roles:
     - partition-disk


### PR DESCRIPTION
play ```hosts``` other than ```all``` prevents to use custom hosts on commandline, so we need ```hosts: all``` in plays

Tool also expects that you copy some yaml file - I want it to be usable as is. No other steps than running playbook are neccessary